### PR TITLE
changed case of svg widget include to work on linux

### DIFF
--- a/universalButtonSource/universalButton.lcb
+++ b/universalButtonSource/universalButton.lcb
@@ -68,7 +68,7 @@ widget community.livecode.rabit.universalbutton
 use com.livecode.canvas
 use com.livecode.widget
 use com.livecode.engine
-use com.livecode.library.iconSVG
+use com.livecode.library.iconsvg
 use com.livecode.library.widgetutils
 use com.livecode.math
 use com.livecode.char


### PR DESCRIPTION
Got an error trying to compile the lcb file on linux because of case-mismatching.
Simple change to fix that.